### PR TITLE
Make sure search engines know where to find the canonical content

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,4 +1,5 @@
 <link rel="sitemap" type="application/xml" href="/sitemap.xml"/>
+<link rel="canonical" href="https://superwerker.workshop.aws{{ .RelPermalink }}"/>
 
 <meta property="og:type" content="website"/>
 <meta property="og:title" content="{{ .Title }}" />


### PR DESCRIPTION
the workshop content is currently deployed on superwerker.awsworkshop.io and superwerker.workshop.aws

Since we might not be able to redirect superwerker.awsworkshop.io to superwerker.workshop.aws, we can give search engines the hint that the canonical content is hosted on superwerker.workshop.aws